### PR TITLE
feat: Add thumbnail generation and integration workflow

### DIFF
--- a/AG_system/contextual_photo_integration/scripts/create_thumbnails.py
+++ b/AG_system/contextual_photo_integration/scripts/create_thumbnails.py
@@ -1,0 +1,203 @@
+import os
+import pandas as pd
+from pathlib import Path
+from PIL import Image
+
+# =======================================================================
+# IMPORTANT NOTE: UNTESTED SCRIPT
+# This script has been code-generated and reviewed, but it has NOT been
+# run in a live environment with actual data.
+# THOROUGH TESTING IS REQUIRED before relying on its output.
+# Key areas to test:
+#   - Correct loading and parsing of processing_lineage.csv.
+#   - Accurate path construction for source and thumbnail images.
+#   - Successful thumbnail generation to the specified dimensions.
+#   - Correct population of new thumbnail-related columns in the CSV.
+#   - Statefulness (skipping already processed items on re-runs).
+#   - Error handling for missing files or corrupted images.
+# =======================================================================
+
+# Constants
+THUMBNAIL_HEIGHT = 360
+LINEAGE_DIR_NAME = "lineage"
+PROCESSED_LINEAGE_FILENAME = "processing_lineage.csv"
+SOURCE_WEBP_DIR_NAME = "processed_webp"
+THUMBNAIL_OUTPUT_DIR_NAME = "processed_webp_thumbnails"
+THUMBNAIL_SUFFIX = "-thumb.webp"
+
+def main():
+    # Construct paths
+    script_path = Path(__file__).resolve()
+    parent_dir = script_path.parent.parent  # AG_system/contextual_photo_integration/
+
+    lineage_dir = parent_dir / LINEAGE_DIR_NAME
+    input_csv_path = lineage_dir / PROCESSED_LINEAGE_FILENAME
+    source_webp_dir = parent_dir / SOURCE_WEBP_DIR_NAME
+    thumbnail_output_dir = parent_dir / THUMBNAIL_OUTPUT_DIR_NAME
+
+    # Create thumbnail output directory
+    os.makedirs(thumbnail_output_dir, exist_ok=True)
+    print(f"Thumbnail output directory: {thumbnail_output_dir}")
+
+    # Check if input CSV exists
+    if not input_csv_path.exists():
+        print(f"Error: Input CSV file not found at {input_csv_path}")
+        return
+
+    print(f"Loading CSV from: {input_csv_path}")
+    df = pd.read_csv(input_csv_path)
+
+    # Initialize new thumbnail-related columns if they don't exist
+    thumbnail_columns = {
+        'thumbnail_final_filename': None,
+        'thumbnail_processed_path': None,
+        'thumbnail_width': None,
+        'thumbnail_height': None,
+        'thumbnail_file_size_bytes': None,
+        'thumbnail_generation_status': '', # empty string for not processed yet
+        'thumbnail_error_message': ''
+    }
+
+    for col, default_value in thumbnail_columns.items():
+        if col not in df.columns:
+            df[col] = default_value
+            if default_value is None and col in ['thumbnail_width', 'thumbnail_height', 'thumbnail_file_size_bytes']:
+                 df[col] = pd.NA # Use pd.NA for numeric types for better pandas handling
+            elif default_value is None:
+                 df[col] = ''
+
+
+    processed_count = 0
+    skipped_count = 0
+    error_count = 0
+
+    print("\n" + "="*60)
+    print("IMPORTANT: This script (`create_thumbnails.py`) is UNTESTED.")
+    print("Please verify its output carefully after the first run.")
+    print("="*60 + "\n")
+
+    print(f"Starting thumbnail generation for {len(df)} entries...")
+
+    for index, row in df.iterrows():
+        try:
+            # Get source WebP image details
+            source_processed_file_path_str = row.get('processed_file_path', '')
+            source_final_filename = row.get('final_filename', '')
+
+            # Handle potential NaN or empty values for path
+            if pd.isna(source_processed_file_path_str) or not source_processed_file_path_str:
+                source_processed_file_path_str = '' # Ensure it's a string for Path object
+
+            if not source_final_filename: # Should ideally not happen if CSV is clean
+                print(f"Row {index}: Skipping due to missing 'final_filename'.")
+                df.loc[index, 'thumbnail_generation_status'] = 'error_missing_data'
+                df.loc[index, 'thumbnail_error_message'] = "Missing 'final_filename' in source CSV row."
+                error_count += 1
+                continue
+
+            # Check thumbnail_generation_status
+            if row.get('thumbnail_generation_status') == 'completed':
+                print(f"Row {index}: Thumbnail for '{source_final_filename}' already marked as 'completed'. Skipping.")
+                skipped_count += 1
+                continue
+
+            # Construct expected thumbnail filename
+            source_path_obj = Path(source_final_filename)
+            thumbnail_filename = f"{source_path_obj.stem}{THUMBNAIL_SUFFIX}"
+            thumbnail_full_output_path = thumbnail_output_dir / thumbnail_filename
+
+            # Construct full source path
+            # The 'processed_file_path' in CSV is expected to be relative to 'source_webp_dir' or absolute
+            # For robustness, let's assume it's either absolute or relative to the parent_dir/SOURCE_WEBP_DIR_NAME
+            if not source_processed_file_path_str: # if empty after initial check
+                 full_source_webp_path = source_webp_dir / source_final_filename
+            else:
+                path_from_csv = Path(source_processed_file_path_str)
+                if path_from_csv.is_absolute():
+                    full_source_webp_path = path_from_csv
+                else:
+                    # This assumes processed_file_path is like "processed_webp/image.webp"
+                    # and we want to ensure it's correctly joined with the base source_webp_dir
+                    # If it already contains SOURCE_WEBP_DIR_NAME, Path should handle it.
+                    # If it's just the filename, it will be joined.
+                    full_source_webp_path = source_webp_dir / path_from_csv.name
+
+
+            print(f"Row {index}: Processing '{source_final_filename}'. Source: '{full_source_webp_path}'")
+
+            if not full_source_webp_path.exists():
+                print(f"Row {index}: Source WebP file not found at '{full_source_webp_path}'.")
+                df.loc[index, 'thumbnail_generation_status'] = 'error_source_missing'
+                df.loc[index, 'thumbnail_error_message'] = f"Source file not found: {full_source_webp_path}"
+                error_count += 1
+                continue
+
+            # Image Processing
+            try:
+                img = Image.open(str(full_source_webp_path))
+                original_width, original_height = img.size
+
+                if original_height == 0: # Avoid division by zero
+                    raise ValueError("Original image height is zero.")
+
+                new_width = int((original_width / original_height) * THUMBNAIL_HEIGHT)
+                if new_width == 0: # Ensure minimum width of 1px for safety
+                    new_width = 1
+
+                resized_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.LANCZOS)
+
+                # Ensure the image mode is compatible with WebP saving if it's not already
+                if resized_img.mode not in ['RGB', 'RGBA']:
+                    print(f"Row {index}: Converting image from mode {resized_img.mode} to RGB for WebP saving.")
+                    resized_img = resized_img.convert('RGB')
+
+                resized_img.save(str(thumbnail_full_output_path), 'WEBP')
+                thumbnail_file_size = os.path.getsize(str(thumbnail_full_output_path))
+
+                # Update DataFrame
+                df.loc[index, 'thumbnail_final_filename'] = thumbnail_filename
+                df.loc[index, 'thumbnail_processed_path'] = str(thumbnail_full_output_path.relative_to(parent_dir))
+                df.loc[index, 'thumbnail_width'] = new_width
+                df.loc[index, 'thumbnail_height'] = THUMBNAIL_HEIGHT
+                df.loc[index, 'thumbnail_file_size_bytes'] = thumbnail_file_size
+                df.loc[index, 'thumbnail_generation_status'] = 'completed'
+                df.loc[index, 'thumbnail_error_message'] = ''
+
+                print(f"Row {index}: Successfully created thumbnail '{thumbnail_filename}' ({new_width}x{THUMBNAIL_HEIGHT}).")
+                processed_count += 1
+
+            except Exception as e:
+                print(f"Row {index}: Error processing image '{source_final_filename}': {e}")
+                df.loc[index, 'thumbnail_generation_status'] = 'error_generating'
+                df.loc[index, 'thumbnail_error_message'] = str(e)
+                error_count += 1
+                # Do not delete thumbnail_full_output_path if it exists but was partial/corrupt
+                # The next run might re-process or it can be manually checked.
+
+        except Exception as outer_e: # Catch errors in row processing logic itself
+            print(f"Row {index}: Critical error processing row: {outer_e}")
+            # Ensure some status is set if not already
+            if pd.isna(df.loc[index, 'thumbnail_generation_status']) or not df.loc[index, 'thumbnail_generation_status']:
+                 df.loc[index, 'thumbnail_generation_status'] = 'error_processing_row'
+            df.loc[index, 'thumbnail_error_message'] = df.loc[index, 'thumbnail_error_message'] + f" | Outer error: {str(outer_e)}"
+            error_count +=1
+
+
+    # Save the updated DataFrame
+    try:
+        df.to_csv(input_csv_path, index=False)
+        print(f"\nUpdated CSV saved to: {input_csv_path}")
+    except Exception as e:
+        print(f"\nError saving updated CSV to {input_csv_path}: {e}")
+        print("Please check file permissions or disk space.")
+
+    # Print summary
+    print("\n--- Thumbnail Generation Summary ---")
+    print(f"Total entries in CSV: {len(df)}")
+    print(f"Successfully processed: {processed_count}")
+    print(f"Skipped (already completed): {skipped_count}")
+    print(f"Failed (errors): {error_count}")
+    print("----------------------------------")
+
+if __name__ == '__main__':
+    main()

--- a/AG_system/contextual_photo_integration/scripts/merge_wordpress_data.py
+++ b/AG_system/contextual_photo_integration/scripts/merge_wordpress_data.py
@@ -2,9 +2,35 @@ import pandas as pd
 import os
 from pathlib import Path
 
+# Script modified to support merging WordPress URLs for both full-size
+# images and thumbnails. It now expects `processing_lineage.csv` to
+# potentially contain `thumbnail_final_filename` and expects
+# `wordpress_urls.csv` to contain URLs for both types of images.
+# The script adds `wordpress_url_fullsize` and `wordpress_url_thumbnail`
+# to the output `complete_image_lineage.csv`.
+
+# Helper function to get a normalized stem from a filename series
+def get_normalized_stem_from_filename(filename_series):
+    """
+    Takes a pandas Series of filenames, extracts the stem (filename without extension),
+    handles potential NaN or empty values, and normalizes the stem.
+    Normalization: lowercases, replaces spaces with hyphens, removes tildes.
+    """
+    stems = []
+    for fname in filename_series:
+        if pd.isna(fname) or fname == '':
+            stems.append('') # Keep it as an empty string for consistent type, merge will fail as expected
+        else:
+            stems.append(os.path.splitext(str(fname))[0])
+
+    stem_series = pd.Series(stems, index=filename_series.index)
+    # Normalize: lowercasing, replacing spaces with hyphens, and REMOVING tildes.
+    return stem_series.str.lower().str.replace(' ', '-', regex=False).str.replace('~', '', regex=False)
+
 def merge_wordpress_data():
     # Define the directory where all data files are located
-    lineage_dir = Path('lineage')
+    script_dir = Path(__file__).resolve().parent
+    lineage_dir = script_dir.parent / 'lineage' # Assumes script is in scripts/, lineage is one level up
 
     # Define paths to input and output files using the lineage_dir
     processing_lineage_path = lineage_dir / 'processing_lineage.csv'
@@ -19,40 +45,124 @@ def merge_wordpress_data():
         print(f"❌ Error: Input file not found at '{wordpress_urls_path}'")
         return
 
-    # Load the data using the full path variables
+    print(f"🔄 Loading processing lineage data from: {processing_lineage_path}")
     lineage_df = pd.read_csv(processing_lineage_path)
+    print(f"🔄 Loading WordPress URL data from: {wordpress_urls_path}")
     wordpress_df = pd.read_csv(wordpress_urls_path)
     
-    # Check for the required 'filename' column
+    # Check for the required columns
     if 'filename' not in wordpress_df.columns:
         print(f"❌ Error: The required column 'filename' was not found in '{wordpress_urls_path}'.")
         return
+    if 'url' not in wordpress_df.columns:
+        print(f"❌ Error: The required column 'url' was not found in '{wordpress_urls_path}'.")
+        return
+    if 'final_filename' not in lineage_df.columns:
+        print(f"❌ Error: The required column 'final_filename' was not found in '{processing_lineage_path}'.")
+        return
 
-    # This function now perfectly mimics WordPress's "slugify" behavior
-    # by lowercasing, replacing spaces with hyphens, and REMOVING tildes.
-    def normalize_key(series):
-        return series.str.lower().str.replace(' ', '-', regex=False).str.replace('~', '', regex=False)
+    # Ensure 'thumbnail_final_filename' exists in lineage_df, add if not (with NaNs)
+    if 'thumbnail_final_filename' not in lineage_df.columns:
+        print(f"⚠️ Warning: 'thumbnail_final_filename' column not found in '{processing_lineage_path}'. Adding it with empty values.")
+        lineage_df['thumbnail_final_filename'] = pd.NA
 
-    # Create the original file stems
-    lineage_df['file_stem'] = lineage_df['final_filename'].apply(lambda x: os.path.splitext(x)[0])
-    wordpress_df['file_stem'] = wordpress_df['filename'].apply(lambda x: os.path.splitext(x)[0])
 
-    # Create new, fully normalized columns to merge on
-    lineage_df['normalized_stem'] = normalize_key(lineage_df['file_stem'])
-    wordpress_df['normalized_stem'] = normalize_key(wordpress_df['file_stem'])
+    # --- First Merge: Full-size image URLs ---
+    print("🔄 Preparing for full-size image URL merge...")
+    lineage_df['normalized_stem_lineage_full'] = get_normalized_stem_from_filename(lineage_df['final_filename'])
+    wordpress_df['normalized_stem_wp'] = get_normalized_stem_from_filename(wordpress_df['filename'])
+
+    # Merge for full-size images
+    # Suffixes: _lineage will be applied to overlapping columns from lineage_df (left), _wp_full to those from wordpress_df (right)
+    merged_df = pd.merge(lineage_df, wordpress_df[['normalized_stem_wp', 'filename', 'url']],
+                         left_on='normalized_stem_lineage_full', right_on='normalized_stem_wp',
+                         how='left', suffixes=('_lineage', '_wp_full'))
+
+    # Rename columns from the first merge
+    merged_df.rename(columns={'url': 'wordpress_url_fullsize',
+                              'filename': 'wordpress_filename_fullsize'}, inplace=True)
+    print("✅ Full-size image URLs merged.")
+
+    # --- Second Merge: Thumbnail image URLs ---
+    print("🔄 Preparing for thumbnail image URL merge...")
+    # Create normalized stem for thumbnails in the merged_df (which is lineage_df + fullsize URL info)
+    # Handle cases where thumbnail_final_filename might be NaN or empty string
+    merged_df['normalized_stem_lineage_thumb'] = get_normalized_stem_from_filename(merged_df['thumbnail_final_filename'])
+
+    # wordpress_df['normalized_stem_wp'] can be reused from the first merge preparation.
+    # Suffixes: _main will be applied to overlapping columns from merged_df (left), _wp_thumb to those from wordpress_df (right)
+    # We only need 'url' and 'filename' from wordpress_df for thumbnails
+    final_merged_df = pd.merge(merged_df, wordpress_df[['normalized_stem_wp', 'filename', 'url']],
+                               left_on='normalized_stem_lineage_thumb', right_on='normalized_stem_wp',
+                               how='left', suffixes=('_main', '_wp_thumb'))
+
+    # Rename columns from the second merge
+    final_merged_df.rename(columns={'url': 'wordpress_url_thumbnail',
+                                    'filename': 'wordpress_filename_thumbnail'}, inplace=True)
+    print("✅ Thumbnail image URLs merged.")
+
+    # --- Column Cleanup ---
+    columns_to_drop = [
+        'normalized_stem_lineage_full',      # Used for 1st merge
+        'normalized_stem_wp_main',           # wp_stem from 1st merge (if not overwritten or suffixed correctly) - check actual name
+        'normalized_stem_wp_wp_full',        # wp_stem from 1st merge (another possible name due to suffixes)
+        'normalized_stem_lineage_thumb',     # Used for 2nd merge
+        'normalized_stem_wp_wp_thumb',       # wp_stem from 2nd merge
+        'normalized_stem_wp',                # Original normalized stem in wordpress_df if it gets carried over
+        # Check for columns like 'normalized_stem_wp_x', 'normalized_stem_wp_y' if suffixes caused them
+    ]
+    # Add specific suffixed versions of 'normalized_stem_wp' that might have been created
+    # The suffixes in pd.merge apply to overlapping columns *other than the merge key*.
+    # The right key ('normalized_stem_wp') might appear as 'normalized_stem_wp_wp_full' or 'normalized_stem_wp_wp_thumb'
+    # if it was also in the left df before merge, or just 'normalized_stem_wp' if it was unique.
+    # Let's inspect columns and drop defensively.
+
+    # Drop columns that exist in the dataframe
+    existing_cols_to_drop = [col for col in columns_to_drop if col in final_merged_df.columns]
     
-    # Merge the data on the new, robust normalized key
-    merged_df = pd.merge(lineage_df, wordpress_df, on='normalized_stem', how='left', suffixes=('_proc', '_wp'))
+    # The key 'normalized_stem_wp' from wordpress_df was used in two merges.
+    # In the first merge, it was `right_on='normalized_stem_wp'`. It won't be in `merged_df` unless it was also in `lineage_df`.
+    # In the second merge, it was `right_on='normalized_stem_wp'`.
+    # Let's explicitly drop the helper columns created on the main dataframe:
+    final_cleanup_cols = ['normalized_stem_lineage_full', 'normalized_stem_lineage_thumb']
+    # Also drop the 'normalized_stem_wp' if it was brought from the right side and not renamed.
+    # After the first merge, 'normalized_stem_wp' (from wordpress_df) is not needed.
+    # After the second merge, 'normalized_stem_wp' (from wordpress_df) is not needed.
+    # The `wordpress_df[['normalized_stem_wp', ...]]` syntax should prevent other columns from wordpress_df from polluting.
+    # The `suffixes` ensure that 'filename' and 'url' are uniquely named.
+    # The `normalized_stem_wp` on the right side of the merge does not get added to the final_merged_df unless specified in select, or if it was also a col in left.
+    # So, the primary columns to drop are those created on the left DataFrame for merging.
+
+    if 'normalized_stem_wp_main' in final_merged_df.columns: # From first merge if 'normalized_stem_wp' was also in lineage_df
+        final_cleanup_cols.append('normalized_stem_wp_main')
+    if 'normalized_stem_wp_wp_full' in final_merged_df.columns: # From first merge, if right df's key was suffixed
+         final_cleanup_cols.append('normalized_stem_wp_wp_full')
+
+    # The 'normalized_stem_wp' from `wordpress_df` is used as a merge key but should not remain as a separate column
+    # in `final_merged_df` unless it was part of the selection or an overlapping column name from the left table.
+    # The explicit selection `wordpress_df[['normalized_stem_wp', 'filename', 'url']]` means `normalized_stem_wp` is used as the key
+    # and `filename`, `url` are the values brought in. If `normalized_stem_wp` is not also in the left table's columns,
+    # it won't be duplicated.
+    # The `suffixes` only apply if columns *other than the merge key* have the same name.
+
+    # Let's be explicit about what we expect in `wordpress_df` for the merge:
+    # `wordpress_df_subset_full = wordpress_df[['normalized_stem_wp', 'filename', 'url']]`
+    # `merged_df = pd.merge(lineage_df, wordpress_df_subset_full, ...)`
+    # `wordpress_df_subset_thumb = wordpress_df[['normalized_stem_wp', 'filename', 'url']]`
+    # `final_merged_df = pd.merge(merged_df, wordpress_df_subset_thumb, ...)`
+    # This structure means 'normalized_stem_wp' is used as the key and won't create extra output columns named 'normalized_stem_wp_x' etc.
+    # So, we only need to drop the keys created on the left dataframe:
     
-    # Clean up all temporary helper columns
-    merged_df.drop(columns=['file_stem_proc', 'file_stem_wp', 'normalized_stem'], inplace=True)
-    # --- END FINAL FIX ---
+    final_merged_df.drop(columns=final_cleanup_cols, inplace=True, errors='ignore')
     
     # Save the final output to the lineage directory
-    merged_df.to_csv(output_path, index=False)
+    final_merged_df.to_csv(output_path, index=False)
     
-    print("✅ WordPress URLs merged with processing lineage")
+    print(f"✅ WordPress URLs for full-size and thumbnails merged with processing lineage.")
     print(f"Output: {output_path}")
+    expected_cols = ['md5_hash', 'final_filename', 'thumbnail_final_filename', 'wordpress_url_fullsize', 'wordpress_filename_fullsize', 'wordpress_url_thumbnail', 'wordpress_filename_thumbnail']
+    print(f"Expected columns include: {', '.join(expected_cols)}")
+    print("Please verify all expected columns are present and helper columns are dropped.")
 
 if __name__ == '__main__':
     merge_wordpress_data()


### PR DESCRIPTION
New script `create_thumbnails.py`:
- Generates thumbnails (360px height) for processed WebP images.
- Stores thumbnails in `processed_webp_thumbnails/`.
- Updates `processing_lineage.csv` with thumbnail metadata.
- IMPORTANT: This script is newly generated and has not been run in a live environment. Thorough testing is required.

Modified `merge_wordpress_data.py`:
- Updated to merge WordPress URLs for both full-size images and the new thumbnails.
- Adds `wordpress_url_fullsize` and `wordpress_url_thumbnail` to `complete_image_lineage.csv`.

Updated `README.md`:
- Documents the new thumbnail generation script and its place in the workflow.
- Details changes to WordPress upload process (include thumbnails) and URL retrieval.
- Reflects new metadata fields in the final dataset.
- Includes warnings about the untested status of `create_thumbnails.py`.