### PR TITLE
Refactor scripts to use robust relative paths

### DIFF
--- a/AG_system/contextual_photo_integration/scripts/cleanup_lineage_data.py
+++ b/AG_system/contextual_photo_integration/scripts/cleanup_lineage_data.py
@@ -7,10 +7,10 @@ def cleanup_lineage_data():
     Remove lineage records for files that don't actually exist,
     keeping only records for files that were successfully processed.
     """
-    lineage_dir = Path('lineage')
-    json_path = lineage_dir / 'processing_lineage.json'
-    csv_path = lineage_dir / 'processing_lineage.csv'
-    processed_dir = Path('processed_webp')
+    base_dir = Path(__file__).resolve().parent.parent
+    json_path = base_dir / 'lineage' / 'processing_lineage.json'
+    csv_path = base_dir / 'lineage' / 'processing_lineage.csv'
+    processed_dir = base_dir / 'processed_webp'
     
     print("Loading processing lineage...")
     

--- a/AG_system/contextual_photo_integration/scripts/extract_takeout_metadata.py
+++ b/AG_system/contextual_photo_integration/scripts/extract_takeout_metadata.py
@@ -11,9 +11,10 @@ def extract_takeout_metadata():
     This script enhances the complete_image_lineage.csv with rich metadata from original Takeout exports.
     """
     print("=== Extracting Takeout Metadata ===")
+    base_dir = Path(__file__).resolve().parent.parent
     
     # Define paths
-    lineage_file = Path('lineage/complete_image_lineage.csv')
+    lineage_file = base_dir / 'lineage' / 'complete_image_lineage.csv'
     
     if not lineage_file.exists():
         print(f"❌ Error: Lineage file not found at {lineage_file}")
@@ -66,7 +67,7 @@ def extract_takeout_metadata():
             
             # Search for the JSON file in all takeout_extracted subdirectories
             found_json = None
-            takeout_dir = Path('takeout_extracted')
+            takeout_dir = base_dir / 'takeout_extracted'
             if takeout_dir.exists():
                 for json_candidate in takeout_dir.rglob(json_filename):
                     found_json = json_candidate

--- a/AG_system/contextual_photo_integration/scripts/final_enrichment.py
+++ b/AG_system/contextual_photo_integration/scripts/final_enrichment.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 import vertexai
 from vertexai.preview.generative_models import GenerativeModel, Part
 --- Configuration ---
@@ -7,15 +8,16 @@ LOCATION = "us-central1"           # The GCP region for Vertex AI
 MODEL_NAME = "gemini-pro-vision"   # The generative model for vision tasks
 --- Main Logic ---
 def final_enrich_data():
-# Initialize Vertex AI
-vertexai.init(project=PROJECT_ID, location=LOCATION)
-# Load the vision model
-vision_model = GenerativeModel(MODEL_NAME)
-# Load merged lineage data from Phase 3
-master_df = pd.read_csv('complete_image_lineage.csv')
+    base_dir = Path(__file__).resolve().parent.parent
+    # Initialize Vertex AI
+    vertexai.init(project=PROJECT_ID, location=LOCATION)
+    # Load the vision model
+    vision_model = GenerativeModel(MODEL_NAME)
+    # Load merged lineage data from Phase 3
+    master_df = pd.read_csv(base_dir / 'lineage' / 'complete_image_lineage.csv')
   
 # --- AI Enrichment ---  
-ai_descriptions = []  
+    ai_descriptions = []
 print("\nStarting Vertex AI enrichment...")
 
 for index, row in master_df.iterrows():  
@@ -36,14 +38,14 @@ for index, row in master_df.iterrows():
         print(error_message)  
         ai_descriptions.append(error_message)  
           
-master_df['ai_description'] = ai_descriptions  
+    master_df['ai_description'] = ai_descriptions
   
 # Clean up and save  
-master_df.drop(columns=['file_stem_x', 'file_stem_y', 'filename'], inplace=True, errors='ignore')  
-master_df.to_csv('FINAL_MASTER_DATA.csv', index=False)  
+    master_df.drop(columns=['file_stem_x', 'file_stem_y', 'filename'], inplace=True, errors='ignore')
+    master_df.to_csv(base_dir / 'lineage' / 'FINAL_MASTER_DATA.csv', index=False)
   
-print("\n\n--- Process Complete ---")
-print("Final, unified dataset saved to 'FINAL_MASTER_DATA.csv'")
+    print("\n\n--- Process Complete ---")
+    print(f"Final, unified dataset saved to '{base_dir / 'lineage' / 'FINAL_MASTER_DATA.csv'}'")
 
 if __name__ == '__main__':
     final_enrich_data()

--- a/AG_system/contextual_photo_integration/scripts/fix_lineage_MD5s.py
+++ b/AG_system/contextual_photo_integration/scripts/fix_lineage_MD5s.py
@@ -19,9 +19,10 @@ def fix_lineage_md5s():
     """
     print("=== Adding Processed File MD5s to Lineage ===")
     print("This preserves original MD5s while adding processed file MD5s for matching")
+    base_dir = Path(__file__).resolve().parent.parent
     
-    lineage_file = Path('lineage/complete_image_lineage.csv')
-    processed_dir = Path('processed_webp')
+    lineage_file = base_dir / 'lineage' / 'complete_image_lineage.csv'
+    processed_dir = base_dir / 'processed_webp'
     
     if not lineage_file.exists():
         print(f"❌ Lineage file not found: {lineage_file}")

--- a/AG_system/contextual_photo_integration/scripts/generate_thumbnails.py
+++ b/AG_system/contextual_photo_integration/scripts/generate_thumbnails.py
@@ -1,17 +1,17 @@
-import os
 import json
 from PIL import Image
+from pathlib import Path
 
 # Define paths
-base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-processed_webp_dir = os.path.join(base_dir, 'processed_webp')
-processed_webp_thumbnails_dir = os.path.join(base_dir, 'processed_webp_thumbnails')
-lineage_file_path = os.path.join(base_dir, 'lineage', 'processing_lineage.json')
+base_dir = Path(__file__).resolve().parent.parent
+processed_webp_dir = base_dir / 'processed_webp'
+processed_webp_thumbnails_dir = base_dir / 'processed_webp_thumbnails'
+lineage_file_path = base_dir / 'lineage' / 'processing_lineage.json'
 
 # Create thumbnails directory if it doesn't exist
-os.makedirs(processed_webp_thumbnails_dir, exist_ok=True)
+processed_webp_thumbnails_dir.mkdir(parents=True, exist_ok=True)
 
-if os.path.exists(lineage_file_path):
+if lineage_file_path.exists():
     try:
         with open(lineage_file_path, 'r') as f:
             processing_lineage_list = json.load(f)
@@ -37,30 +37,30 @@ def generate_thumbnails():
         if final_filename:
             lineage_by_filename[final_filename] = record
 
-    for filename in os.listdir(processed_webp_dir):
-        if not filename.endswith(".webp"):
+    for filename_path_obj in processed_webp_dir.iterdir():
+        if not filename_path_obj.name.endswith(".webp"):
             continue
 
         # Extract stem for thumbnail naming (remove .webp extension)
-        original_stem = filename.split('.')[0]
+        original_stem = filename_path_obj.stem
         thumbnail_filename = f"{original_stem}-h{THUMBNAIL_HEIGHT}-thumb.webp"
-        thumbnail_path = os.path.join(processed_webp_thumbnails_dir, thumbnail_filename)
-        original_image_path = os.path.join(processed_webp_dir, filename)
+        thumbnail_path = processed_webp_thumbnails_dir / thumbnail_filename
+        original_image_path = filename_path_obj # Use the Path object directly
 
-        lineage_record = lineage_by_filename.get(filename)
+        lineage_record = lineage_by_filename.get(filename_path_obj.name)
         if not lineage_record:
-            print(f"Warning: No lineage record found for {filename}")
+            print(f"Warning: No lineage record found for {filename_path_obj.name}")
             continue
 
         try:
-            if os.path.exists(thumbnail_path):
+            if thumbnail_path.exists():
                 # Thumbnail exists, get its info and update lineage
                 with Image.open(thumbnail_path) as thumb_img:
                     thumbnail_width, thumbnail_height = thumb_img.size
-                thumbnail_file_size_bytes = os.path.getsize(thumbnail_path)
+                thumbnail_file_size_bytes = thumbnail_path.stat().st_size
 
                 lineage_record['thumbnail_final_filename'] = thumbnail_filename
-                lineage_record['thumbnail_processed_path'] = thumbnail_path
+                lineage_record['thumbnail_processed_path'] = str(thumbnail_path) # Store as string for JSON
                 lineage_record['thumbnail_width'] = thumbnail_width
                 lineage_record['thumbnail_height'] = thumbnail_height
                 lineage_record['thumbnail_file_size_bytes'] = thumbnail_file_size_bytes
@@ -77,11 +77,11 @@ def generate_thumbnails():
                     resized_img = img.resize((new_width, THUMBNAIL_HEIGHT), Image.Resampling.LANCZOS)
                     resized_img.save(thumbnail_path, 'WEBP')
 
-                    thumbnail_file_size_bytes = os.path.getsize(thumbnail_path)
+                    thumbnail_file_size_bytes = thumbnail_path.stat().st_size
                     thumbnail_width, thumbnail_height = resized_img.size
 
                     lineage_record['thumbnail_final_filename'] = thumbnail_filename
-                    lineage_record['thumbnail_processed_path'] = thumbnail_path
+                    lineage_record['thumbnail_processed_path'] = str(thumbnail_path) # Store as string for JSON
                     lineage_record['thumbnail_width'] = thumbnail_width
                     lineage_record['thumbnail_height'] = thumbnail_height
                     lineage_record['thumbnail_file_size_bytes'] = thumbnail_file_size_bytes
@@ -92,9 +92,9 @@ def generate_thumbnails():
             processed_files += 1
 
         except Exception as e:
-            print(f"Error processing {filename} (or its existing thumbnail {thumbnail_filename}): {e}")
+            print(f"Error processing {filename_path_obj.name} (or its existing thumbnail {thumbnail_filename}): {e}")
             lineage_record['thumbnail_final_filename'] = thumbnail_filename
-            lineage_record['thumbnail_processed_path'] = thumbnail_path
+            lineage_record['thumbnail_processed_path'] = str(thumbnail_path) # Store as string for JSON
             lineage_record['thumbnail_generation_status'] = "failure"
             lineage_record['thumbnail_error_message'] = str(e)
             # Clear other fields if error occurs

--- a/AG_system/contextual_photo_integration/scripts/image_status_check.py
+++ b/AG_system/contextual_photo_integration/scripts/image_status_check.py
@@ -21,11 +21,12 @@ def check_image_status():
     Comprehensive image status check using pandas for reliable CSV parsing.
     """
     print("=== Python Image Status Check ===")
+    base_dir = Path(__file__).resolve().parent.parent
     
     # Define paths
-    processed_webp_dir = Path('processed_webp')
-    thumbnails_dir = Path('processed_webp_thumbnails')
-    lineage_file = Path('lineage/complete_image_lineage.csv')
+    processed_webp_dir = base_dir / 'processed_webp'
+    thumbnails_dir = base_dir / 'processed_webp_thumbnails'
+    lineage_file = base_dir / 'lineage' / 'complete_image_lineage.csv'
     
     print(f"Processed images directory: {processed_webp_dir}")
     print(f"Thumbnails directory: {thumbnails_dir}")

--- a/AG_system/contextual_photo_integration/scripts/prepare_takeout_data.py
+++ b/AG_system/contextual_photo_integration/scripts/prepare_takeout_data.py
@@ -14,13 +14,13 @@ SUPPORTED_VIDEO_EXTENSIONS = ['.mp4', '.mov', '.m4v', '.3gp', '.mpg', '.mpeg', '
 SUPPORTED_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS + SUPPORTED_VIDEO_EXTENSIONS
 
 class TakeoutProcessor:
-    def __init__(self, takeout_dir, output_dir='original_downloads', lineage_dir='lineage'):
-        self.takeout_dir = Path(takeout_dir)
+    def __init__(self, script_base_dir, takeout_dir_arg, output_dir_name='original_downloads', lineage_dir_name='lineage'):
+        self.takeout_dir = Path(takeout_dir_arg)
         if not self.takeout_dir.is_dir():
-            raise FileNotFoundError(f"Takeout directory not found: {takeout_dir}")
+            raise FileNotFoundError(f"Takeout directory not found: {takeout_dir_arg}")
 
-        self.output_dir = Path(output_dir)
-        self.lineage_dir = Path(lineage_dir)
+        self.output_dir = script_base_dir / output_dir_name
+        self.lineage_dir = script_base_dir / lineage_dir_name
         self.output_dir.mkdir(exist_ok=True)
         self.lineage_dir.mkdir(exist_ok=True)
         
@@ -249,7 +249,8 @@ def main():
     parser.add_argument("takeout_dir", help="Path to the directory of an unzipped Takeout album.")
     args = parser.parse_args()
     try:
-        processor = TakeoutProcessor(args.takeout_dir)
+        script_base_dir = Path(__file__).resolve().parent.parent
+        processor = TakeoutProcessor(script_base_dir, args.takeout_dir)
         processor.scan_takeout_directory()
         processor.save_lineage()
         print("\n✅ Processing complete!")

--- a/AG_system/contextual_photo_integration/scripts/process_downloaded_images.py
+++ b/AG_system/contextual_photo_integration/scripts/process_downloaded_images.py
@@ -4,11 +4,13 @@ import datetime
 import pandas as pd
 import json
 from pathlib import Path
+import hashlib
 
 class ImageProcessor:
-    def __init__(self, processed_dir='processed_webp', lineage_dir='lineage'):
-        self.processed_dir = Path(processed_dir)
-        self.lineage_dir = Path(lineage_dir)
+    def __init__(self, base_dir):
+        self.base_dir = base_dir
+        self.processed_dir = base_dir / 'processed_webp'
+        self.lineage_dir = base_dir / 'lineage'
         self.processed_dir.mkdir(exist_ok=True)
         self.lineage_dir.mkdir(exist_ok=True) # Ensure lineage dir exists
         
@@ -137,8 +139,8 @@ class ImageProcessor:
         print(f"\nProcessing lineage saved to {csv_path} and {json_path}")
 
 def main():
-    lineage_dir = Path('lineage')
-    download_lineage_path = lineage_dir / 'download_lineage.csv'
+    base_dir = Path(__file__).resolve().parent.parent
+    download_lineage_path = base_dir / 'lineage' / 'download_lineage.csv'
     
     if not download_lineage_path.exists():
         print(f"❌ Error: Input file not found at '{download_lineage_path}'")
@@ -148,7 +150,7 @@ def main():
     print(f"Loading download records from '{download_lineage_path}'...")
     download_df = pd.read_csv(download_lineage_path).fillna('')
     
-    processor = ImageProcessor()
+    processor = ImageProcessor(base_dir)
     
     # Filter out images that have already been processed
     unprocessed_df = download_df[~download_df['md5_hash'].isin(processor.processed_hashes)]

--- a/AG_system/contextual_photo_integration/scripts/safe_merge_of_misplaced_processing_lineage.json.py
+++ b/AG_system/contextual_photo_integration/scripts/safe_merge_of_misplaced_processing_lineage.json.py
@@ -5,8 +5,9 @@ def merge_thumbnail_data():
     """
     Safely merges thumbnail data from the misplaced root file into the proper lineage file.
     """
-    root_file = Path('processing_lineage.json')
-    lineage_file = Path('lineage/processing_lineage.json')
+    base_dir = Path(__file__).resolve().parent.parent
+    root_file = base_dir / 'processing_lineage.json'
+    lineage_file = base_dir / 'lineage' / 'processing_lineage.json'
     
     print("=== Merging Thumbnail Data ===")
     

--- a/AG_system/contextual_photo_integration/scripts/verify_processing.py
+++ b/AG_system/contextual_photo_integration/scripts/verify_processing.py
@@ -7,9 +7,9 @@ def verify_processing_output():
     """
     Verifies that all successfully prepared files were successfully processed.
     """
-    lineage_dir = Path('lineage')
-    download_lineage_path = lineage_dir / 'download_lineage.csv'
-    processing_lineage_path = lineage_dir / 'processing_lineage.csv'
+    base_dir = Path(__file__).resolve().parent.parent
+    download_lineage_path = base_dir / 'lineage' / 'download_lineage.csv'
+    processing_lineage_path = base_dir / 'lineage' / 'processing_lineage.csv'
 
     # --- 1. Check if both lineage files exist ---
     if not download_lineage_path.exists() or not processing_lineage_path.exists():


### PR DESCRIPTION
This commit addresses an issue where several Python scripts in AG_system/contextual_photo_integration/scripts/ relied on hardcoded relative paths, making them fragile and dependent on the current working directory.

The following scripts were updated to use `Path(__file__).resolve().parent.parent` as a base directory for all file system operations:
- process_downloaded_images.py
- verify_processing.py
- cleanup_lineage_data.py
- extract_takeout_metadata.py
- final_enrichment.py (paths for CSV input/output now correctly point to the lineage directory)
- fix_lineage_MD5s.py
- generate_thumbnails.py (also migrated from os.path to pathlib.Path for consistency)
- image_status_check.py
- prepare_takeout_data.py (class constructor updated to handle base path for output dirs)
- safe_merge_of_misplaced_processing_lineage.json.py

This change makes the scripts more robust and executable from any directory, as per the pattern established in `merge_wordpress_data.py`.