### PR TITLE
feat: Add signature toggle, title case names, and duplicate name check

### DIFF
--- a/email_app/mass_email_app_v2.ipynb
+++ b/email_app/mass_email_app_v2.ipynb
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from collections import defaultdict\n",
+    "from collections import defaultdict, Counter\n",
     "import os\n",
     "import pickle\n",
     "import pypandoc\n",
@@ -165,6 +165,22 @@
     "# Example\n",
     "#attachments = ['/Users/joelswenson/Documents/Adas_spark/code_repo/email_app_local/2025_Adas_Spark_Course_Map.png',\n",
     "#               '/Users/joelswenson/Documents/Adas_spark/code_repo/email_app_local/parking_map.jpg']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Toggle for including the email signature\n",
+    "include_signature = True  # Set to False or 0 to disable\n",
+    "\n",
+    "if include_signature:\n",
+    "    print(\"Email signature is ENABLED.\")\n",
+    "else:\n",
+    "    print(\"Email signature is DISABLED.\")"
    ]
   },
   {
@@ -271,12 +287,39 @@
     "            'name': f\"{row['First Name']} {row['Last Name']}\"\n",
     "        })\n",
     "        continue\n",
-    "    families[email_clean].append(row[\"First Name\"])\n",
+    "    families[email_clean].append(row[\"First Name\"].strip().title())\n",
     "    last_names[email_clean].add(row[\"Last Name\"])  # Collect all last names\n",
     "\n",
     "# Deals with the somewhat common case of a family having the same email address but different last names\n",
     "# Convert sets to formatted strings like \"Smith and Johnson\"\n",
     "last_names = {email: \" and \".join(sorted(names)) for email, names in last_names.items()}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "z9y8x7w6-v5u4-t3s2-r1q0-p9o8n7m6l5k4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check for duplicate names within each family list\n",
+    "for email_clean, names_list in families.items():\n",
+    "    # Convert names to lowercase for case-insensitive comparison\n",
+    "    lower_names_list = [name.lower() for name in names_list]\n",
+    "    name_counts = Counter(lower_names_list)\n",
+    "    duplicates_found = [name for name, count in name_counts.items() if count > 1]\n",
+    "    if duplicates_found:\n",
+    "        # Get original case names for reporting\n",
+    "        original_case_duplicates = []\n",
+    "        temp_lower_duplicates = list(duplicates_found) # Avoid issues if a name appears more than twice\n",
+    "        for original_name in names_list:\n",
+    "            if original_name.lower() in temp_lower_duplicates:\n",
+    "                original_case_duplicates.append(original_name)\n",
+    "                temp_lower_duplicates.remove(original_name.lower())\n",
+    "        # Remove duplicates from the reported list itself if a name was duplicated more than once e.g. ['joe', 'Joe', 'JOE'] -> ['joe']\n",
+    "        # by converting to dict and back to list (preserves order of first seen)\n",
+    "        unique_original_duplicates = list(dict.fromkeys(original_case_duplicates))\n",
+    "        print(f\"Warning: Duplicate names found for {mask_email(email_clean)}: {unique_original_duplicates}\")"
    ]
   },
   {
@@ -398,7 +441,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "email_template = clean_email_formatting(email_template)"
+    "email_template = clean_email_formatting(email_template)\n",
+    "\n",
+    "# Define the HTML signature string\n",
+    "signature_html = '''\n",
+    "<p style=\"color: #555555; font-size: 0.9em;\">\n",
+    "&ndash; Ada's Spark is a registered 501(c)3 charity. Please visit <a href=\"https://adas-spark.org/\">adas-spark.org</a> to donate or to learn about how Ada's Spark is inspiring hope, healing, and lasting change in the battle against childhood cancer.\n",
+    "</p>\n",
+    "'''\n",
+    "\n",
+    "# Append signature if the flag is true\n",
+    "if include_signature:\n",
+    "    email_template += signature_html\n",
+    "    print(\"Appending email signature.\")"
    ]
   },
   {


### PR DESCRIPTION
This commit introduces several enhancements to the mass email notebook:

1.  Email Signature Toggle:
    - Adds a binary flag (`include_signature`) to control the inclusion of a standard email signature.
    - Prints the current status of the signature (on/off) to you.
    - Appends the HTML signature (gray text, clickable link to adas-spark.org) to the email template if the flag is enabled.

2.  Title Case Names:
    - Modifies the name processing logic to convert all first names to title case (e.g., "john" becomes "John") in the salutation.

3.  Identical Name Check:
    - Adds a check to identify if multiple individuals with the same first name (case-insensitive) are registered under a single email address.
    - Prints a warning to you if such duplicates are detected, listing the email and the duplicate names.