### PR TITLE
Add script to enrich QA data with source title and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This project is composed of several key systems:
     *   For detailed information on its design, workflow, and current status, please refer to the [Contextual Photo Integration README](./AG_system/contextual_photo_integration/README.md).
     *   This component has been integrated into the main system. For detailed information on its design, workflow, and current status, please refer to the Contextual Photo Integration README.
     * Q&A Generation & Merging: Manual Q&A generation followed by `AG_system/proof_of_concepts/QC_and_merge_jsons.ipynb` for merging and JSON validation.
+    * Q&A Data Enrichment: `enrich_qa_data.py` script takes the output from the Q&A merging step and enriches it with `source_title` and `source_url` for each answer. This information is derived from the scraped CaringBridge data and is primarily used to allow the front-end to display and link back to the original source posts.
+        *   **Usage:** `python enrich_qa_data.py <path_to_qa_json_input> <path_to_scraped_data_json> <path_to_output_enriched_qa_json>`
+        *   **Example:** `python enrich_qa_data.py AG_system/proof_of_concepts/EXAMPLE_generated_qa_pairs_combined_clean_20250603_214922.json AG_system/EXAMPLE_scraped_data_with_author_and_text_changes.json enriched_qa_output.json`
     * Embedding QC & Vector DB Operations (Pinecone): `AG_system/proof_of_concepts/pincecone/visualization_analysis.ipynb` for embedding quality control, and `AG_system/proof_of_concepts/pincecone/pinecone_poc.ipynb` for uploading embeddings to Pinecone.
     * **Suggestion for Future Enhancement:** To potentially optimize performance and reduce token usage, consider experimenting with sending thumbnails (instead of full-resolution images, where appropriate) to the image-to-text models used in the `AG_system/contextual_photo_integration/scripts/final_enrichment.py` script. This could be particularly relevant for generating brief descriptions or captions.
 
@@ -39,10 +42,11 @@ This repository also contains a custom mail merge tool used for tasks such as em
 1.  `AG_system/scraping/scrape.py` → `scraped_data.json` (raw CaringBridge data).
 2.  `AG_system/scraping/update_authors_and_text.py` → corrected data files.
 3.  Manual Q&A generation (currently via Gemini app).
-4.  `AG_system/proof_of_concepts/QC_and_merge_jsons.ipynb` → Merges Q&A JSON files and performs data quality control and validation.
-5.  `AG_system/proof_of_concepts/pincecone/visualization_analysis.ipynb` → Quality control of embeddings.
-6.  `AG_system/proof_of_concepts/pincecone/pinecone_poc.ipynb` → Upload embeddings to Pinecone vector database.
-7.  `AG_system/static_website/` → Vue.js frontend (deployed to WP Engine and embedded via iframe) calls API endpoints (Node.js serverless functions deployed on Vercel) for user queries.
+4.  `AG_system/proof_of_concepts/QC_and_merge_jsons.ipynb` → Merges Q&A JSON files and performs data quality control and validation, producing an intermediate QA file.
+5.  `enrich_qa_data.py` → Takes the merged QA file and the scraped data file (e.g., `AG_system/EXAMPLE_scraped_data_with_author_and_text_changes.json`) to produce an enriched QA file with `source_title` and `source_url` for linking on the frontend.
+6.  `AG_system/proof_of_concepts/pincecone/visualization_analysis.ipynb` → Quality control of embeddings using the enriched QA file.
+7.  `AG_system/proof_of_concepts/pincecone/pinecone_poc.ipynb` → Upload embeddings from the enriched QA file to Pinecone vector database.
+8.  `AG_system/static_website/` → Vue.js frontend (deployed to WP Engine and embedded via iframe) calls API endpoints (Node.js serverless functions deployed on Vercel) for user queries.
 8.  `AG_system/contextual_photo_integration/` scripts → Process Google Photos Takeout data, generate AI captions, and prepare `FINAL_MASTER_DATA.csv` for enriching the Pinecone vector database with image-related context.
 
 **Key Technologies (Ada's Living Story):**

--- a/enrich_qa_data.py
+++ b/enrich_qa_data.py
@@ -1,0 +1,125 @@
+import json
+import argparse
+import os
+
+# Constant for the site ID, as discussed.
+# This is used to construct the source_url.
+CARINGBRIDGE_SITE_ID = "6f33ada9-525c-3ce3-be6f-34b647b78d2d"
+BASE_URL = f"https://www.caringbridge.org/site/{CARINGBRIDGE_SITE_ID}/post"
+
+def load_json_file(filepath):
+    """Loads a JSON file."""
+    try:
+        # Try with 'utf-8-sig' first to handle potential BOM
+        with open(filepath, 'r', encoding='utf-8-sig') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: File not found at {filepath}")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"Error: Could not decode JSON from {filepath}. Details: {e.msg} (line {e.lineno}, column {e.colno})")
+        # As a fallback, try 'utf-8' if 'utf-8-sig' fails for reasons other than BOM
+        try:
+            print(f"Attempting fallback to 'utf-8' encoding for {filepath}")
+            with open(filepath, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except json.JSONDecodeError as e_utf8:
+            print(f"Error: Fallback to 'utf-8' also failed for {filepath}. Details: {e_utf8.msg} (line {e_utf8.lineno}, column {e_utf8.colno})")
+            return None
+        except Exception as ex_utf8:
+            print(f"An unexpected error occurred during 'utf-8' fallback for {filepath}: {ex_utf8}")
+            return None
+    except Exception as ex:
+        print(f"An unexpected error occurred while loading {filepath}: {ex}")
+        return None
+
+def save_json_file(data, filepath):
+    """Saves data to a JSON file."""
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+        print(f"Successfully saved enriched data to {filepath}")
+    except IOError:
+        print(f"Error: Could not write to file at {filepath}")
+
+def enrich_qa_data(qa_filepath, scraped_data_filepath, output_filepath):
+    """
+    Enriches QA data with source titles and URLs from scraped data.
+
+    Args:
+        qa_filepath (str): Path to the input QA pairs JSON file.
+        scraped_data_filepath (str): Path to the scraped data JSON file.
+        output_filepath (str): Path to save the enriched QA pairs JSON file.
+    """
+    qa_data = load_json_file(qa_filepath)
+    scraped_posts_raw = load_json_file(scraped_data_filepath)
+
+    if qa_data is None or scraped_posts_raw is None:
+        print("Exiting due to errors loading input files.")
+        return
+
+    # Create a dictionary for quick lookup of scraped posts by post_id
+    scraped_posts = {post['post_id']: post for post in scraped_posts_raw if 'post_id' in post}
+
+    enriched_qa_data = []
+
+    for question_block in qa_data:
+        enriched_answers = []
+        if 'answers' in question_block and isinstance(question_block['answers'], list):
+            for answer in question_block['answers']:
+                source_post_ids_str = answer.get("source_post_id", "")
+
+                # Preserve existing source_date
+                # No specific action needed here as we are just adding new fields
+                # and the original answer object (with source_date) is being modified.
+
+                current_titles = []
+                current_urls = []
+
+                if source_post_ids_str:
+                    source_post_id_list = [pid.strip() for pid in source_post_ids_str.split(',')]
+
+                    for post_id in source_post_id_list:
+                        if not post_id: # Handle potential empty strings if IDs are like "id1, , id2"
+                            continue
+
+                        post_info = scraped_posts.get(post_id)
+                        if post_info:
+                            current_titles.append(post_info.get("title", ""))
+                            current_urls.append(f"{BASE_URL}/{post_id}")
+                        else:
+                            print(f"Warning: Post ID '{post_id}' not found in scraped data. Skipping for title/URL enrichment for this ID.")
+                            # Append placeholders or decide how to handle missing data for specific IDs
+                            current_titles.append("") # Or some other placeholder like "Title Not Found"
+                            current_urls.append("")   # Or some other placeholder like "URL Not Found"
+
+
+                # Add new fields as string representations of lists
+                answer["source_title"] = str(current_titles)
+                answer["source_url"] = str(current_urls)
+
+                enriched_answers.append(answer)
+
+            question_block["answers"] = enriched_answers
+        enriched_qa_data.append(question_block)
+
+    save_json_file(enriched_qa_data, output_filepath)
+
+def main():
+    parser = argparse.ArgumentParser(description="Enrich QA JSON data with source titles and URLs.")
+    parser.add_argument("qa_input_filepath", help="Path to the input QA JSON file (e.g., EXAMPLE_generated_qa_pairs_combined_clean_20250603_214922.json)")
+    parser.add_argument("scraped_data_filepath", help="Path to the scraped data JSON file (e.g., AG_system/EXAMPLE_scraped_data_with_author_and_text_changes.json)")
+    parser.add_argument("output_filepath", help="Path to save the enriched output JSON file.")
+
+    args = parser.parse_args()
+
+    # Basic validation for file extensions (optional, but good practice)
+    if not args.qa_input_filepath.endswith('.json') or \
+       not args.scraped_data_filepath.endswith('.json') or \
+       not args.output_filepath.endswith('.json'):
+        print("Warning: Input/output files should preferably be .json files.")
+
+    enrich_qa_data(args.qa_input_filepath, args.scraped_data_filepath, args.output_filepath)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Introduces `enrich_qa_data.py` which takes a QA JSON file and a scraped data JSON file as input.
- For each answer, it adds `source_title` and `source_url` fields based on `source_post_id` lookups in the scraped data.
- The `source_date` field from the input QA file is preserved.
- This enrichment is to support displaying and linking to original sources on the front-end.
- Updates README.md to include this script in the data pipeline description and data flow diagram, along with usage instructions.