### PR TITLE
Add option to save mass emails as drafts

### DIFF
--- a/email_app/mass_email_app_v2.ipynb
+++ b/email_app/mass_email_app_v2.ipynb
@@ -143,10 +143,10 @@
     "csv_file_path = '/Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/listserv_cleaned_12-7-25.csv'\n",
     "\n",
     "# Path to template email in docx format\n",
-    "docx_template_path = '/Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive – Help Brighten the Holidays for Kids at AFCH.docx'\n",
+    "docx_template_path = '/Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive \u2013 Help Brighten the Holidays for Kids at AFCH.docx'\n",
     "\n",
     "# Use custom subject if provided, otherwise use filename\n",
-    "custom_subject = \"3rd Annual Adas Spark Toy Drive – Help Brighten the Holidays for Kids at AFCH\"  # Set this to override the default otherwise set 'custom_subject = None'\n",
+    "custom_subject = \"3rd Annual Adas Spark Toy Drive \u2013 Help Brighten the Holidays for Kids at AFCH\"  # Set this to override the default otherwise set 'custom_subject = None'\n",
     "base_subject = (custom_subject \n",
     "                if custom_subject \n",
     "                else os.path.splitext(os.path.basename(docx_template_path))[0])\n",
@@ -156,6 +156,9 @@
     "# Use last names in subject line? E.g. Should it say \"base_subject - last_name\" \n",
     "#     like \"Ada's 2024 5K - Swenson\"\n",
     "last_name_in_subject_line = 0 # Binary: 0 means don't have last_name in subject line.\n",
+    "\n",
+    "# Save as draft instead of sending immediately?\n",
+    "save_as_draft = True # Set to True to create drafts, False to send emails\n",
     "\n",
     "# Specify the paths to the attachments, initialize empty list if there are no attachments.\n",
     "# You can attach multiple attachments by\n",
@@ -201,7 +204,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current subject format: '3rd Annual Ada's Spark Toy Drive – Help Brighten the Holidays for Kids at AFCH'\n"
+      "Current subject format: '3rd Annual Ada's Spark Toy Drive \u2013 Help Brighten the Holidays for Kids at AFCH'\n"
      ]
     }
    ],
@@ -225,7 +228,7 @@
    ],
    "source": [
     "print(\"Remember that the signature from Ada's Spark is not automtically added to emails if you send emails through the API so put it in the Google Doc if you want it included....there is a way to add it programmatically but it isn't worth the lift and will be hard to make look pretty. Actually I added a function to add the html from this script so just double-check it.\")\n",
-    "# –\n",
+    "# \u2013\n",
     "# Ada's Spark is a registered 501(c)3 charity. Please visit www.adas-spark.org to donate or to learn about how Ada's Spark is inspiring hope, healing, and lasting change in the battle against childhood cancer."
    ]
   },
@@ -362,8 +365,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Docx Template Path: /Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive – Help Brighten the Holidays for Kids at AFCH.docx\n",
-      "HTML Template Path: /Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive – Help Brighten the Holidays for Kids at AFCH.html\n"
+      "Docx Template Path: /Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive \u2013 Help Brighten the Holidays for Kids at AFCH.docx\n",
+      "HTML Template Path: /Users/joelswenson/Documents/Adas_spark/code_repo/github_repo__called_code/code/email_app/3rd Annual Adas Spark Toy Drive \u2013 Help Brighten the Holidays for Kids at AFCH.html\n"
      ]
     }
    ],
@@ -396,7 +399,7 @@
    "source": [
     "def clean_email_formatting(html_content):\n",
     "    \"\"\"\n",
-    "    Clean up HTML formatting issues from Google Docs → HTML conversion for email.\n",
+    "    Clean up HTML formatting issues from Google Docs \u2192 HTML conversion for email.\n",
     "    \n",
     "    Fixes common problems:\n",
     "    - Removes incorrect blockquote tags from bullet points\n",
@@ -485,7 +488,7 @@
     {
      "data": {
       "text/plain": [
-       "'\\n# DEBUG: Let\\'s see what the cleaned HTML looks like\\nprint(\"=== CLEANED HTML AROUND BULLETS ===\")\\nimport re\\nbullet_sections = re.findall(r\\'.{0,100}(?:<li|<ul|<ol|•|&#8226;).{0,200}\\', email_template, re.IGNORECASE | re.DOTALL)\\nfor i, section in enumerate(bullet_sections):\\n    print(f\"Section {i+1}:\")\\n    print(repr(section))\\n    print(\"---\")\\n\\n# Also save the cleaned HTML to inspect\\nwith open(\\'debug_cleaned_template.html\\', \\'w\\') as f:\\n    f.write(email_template)\\nprint(\"Cleaned HTML saved to debug_cleaned_template.html\")\\n'"
+       "'\\n# DEBUG: Let\\'s see what the cleaned HTML looks like\\nprint(\"=== CLEANED HTML AROUND BULLETS ===\")\\nimport re\\nbullet_sections = re.findall(r\\'.{0,100}(?:<li|<ul|<ol|\u2022|&#8226;).{0,200}\\', email_template, re.IGNORECASE | re.DOTALL)\\nfor i, section in enumerate(bullet_sections):\\n    print(f\"Section {i+1}:\")\\n    print(repr(section))\\n    print(\"---\")\\n\\n# Also save the cleaned HTML to inspect\\nwith open(\\'debug_cleaned_template.html\\', \\'w\\') as f:\\n    f.write(email_template)\\nprint(\"Cleaned HTML saved to debug_cleaned_template.html\")\\n'"
       ]
      },
      "execution_count": 43,
@@ -498,7 +501,7 @@
     "# DEBUG: Let's see what the cleaned HTML looks like\n",
     "print(\"=== CLEANED HTML AROUND BULLETS ===\")\n",
     "import re\n",
-    "bullet_sections = re.findall(r'.{0,100}(?:<li|<ul|<ol|•|&#8226;).{0,200}', email_template, re.IGNORECASE | re.DOTALL)\n",
+    "bullet_sections = re.findall(r'.{0,100}(?:<li|<ul|<ol|\u2022|&#8226;).{0,200}', email_template, re.IGNORECASE | re.DOTALL)\n",
     "for i, section in enumerate(bullet_sections):\n",
     "    print(f\"Section {i+1}:\")\n",
     "    print(repr(section))\n",
@@ -603,7 +606,7 @@
    "outputs": [],
    "source": [
     "# If modifying these SCOPES, delete the file token.pickle.\n",
-    "SCOPES = ['https://www.googleapis.com/auth/gmail.send']"
+    "SCOPES = ['https://www.googleapis.com/auth/gmail.send', 'https://www.googleapis.com/auth/gmail.compose']"
    ]
   },
   {
@@ -708,7 +711,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def send_email(service, to, subject, body, attachments=None):\n",
+    "def send_email(service, to, subject, body, attachments=None, save_as_draft=False):\n",
     "    try:\n",
     "        # Create the email message\n",
     "        message = MIMEMultipart()\n",
@@ -725,10 +728,16 @@
     "\n",
     "        raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode()\n",
     "\n",
-    "        # Send the email\n",
-    "        message = (service.users().messages().send(userId=\"me\", body={'raw': raw_message})\n",
-    "                   .execute())\n",
-    "        print('Message Id: %s' % message['id'])\n",
+    "        if save_as_draft:\n",
+    "            draft = {'message': {'raw': raw_message}}\n",
+    "            message = (service.users().drafts().create(userId=\"me\", body=draft)\n",
+    "                       .execute())\n",
+    "            print('Draft Id: %s' % message['id'])\n",
+    "        else:\n",
+    "            # Send the email\n",
+    "            message = (service.users().messages().send(userId=\"me\", body={'raw': raw_message})\n",
+    "                       .execute())\n",
+    "            print('Message Id: %s' % message['id'])\n",
     "        return message\n",
     "    except Exception as e:\n",
     "        print(f'An error occurred while sending email to {mask_email(to)}: {e}')\n",
@@ -822,27 +831,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def send_emails_with_backoff(service, personalized_emails, last_names, base_subject, attachments=None):\n",
+    "def send_emails_with_backoff(service, personalized_emails, last_names, base_subject, attachments=None, save_as_draft=False):\n",
     "    \"\"\"Send emails with exponential backoff for rate limits and transient failures.\"\"\"\n",
     "    for email_clean, personalized_email in personalized_emails.items():\n",
     "        attempt = 0\n",
     "        while attempt < MAX_RETRIES:\n",
     "            try:\n",
-    "                print(f\"Sending email to: {mask_email(email_clean)}\")\n",
+    "                action = \"Drafting\" if save_as_draft else \"Sending\"\n",
+    "                print(f\"{action} email to: {mask_email(email_clean)}\")\n",
     "                last_name = last_names[email_clean]\n",
     "                if last_name_in_subject_line:\n",
     "                    subject = f\"{base_subject} - {last_name}\"\n",
     "                else:\n",
     "                    subject = base_subject\n",
     "                \n",
-    "                result = send_email(service, email_clean, subject, personalized_email, attachments)\n",
+    "                result = send_email(service, email_clean, subject, personalized_email, attachments, save_as_draft=save_as_draft)\n",
     "                \n",
     "                if result:  # Success\n",
-    "                    print(f\"Email sent successfully to {mask_email(email_clean)}\")\n",
+    "                    action_past = \"drafted\" if save_as_draft else \"sent\"\n",
+    "                    print(f\"Email {action_past} successfully to {mask_email(email_clean)}\")\n",
     "                    time.sleep(random.uniform(1, 3))  # Small random delay between sends\n",
     "                    break  # Exit loop on success\n",
     "                else:\n",
-    "                    raise Exception(\"Unknown email sending failure\")\n",
+    "                    raise Exception(f\"Unknown email {'drafting' if save_as_draft else 'sending'} failure\")\n",
     "            except HttpError as e:\n",
     "                if e.resp.status in [403, 429, 500, 503]:  # Handle rate limits and server errors\n",
     "                    attempt += 1\n",
@@ -953,7 +964,7 @@
     "    # Create a single-email dictionary for testing\n",
     "    test_emails_payload = {test_email: personalized_emails[test_email]}\n",
     "    # Use the new backoff function with just one email\n",
-    "    send_emails_with_backoff(service, test_emails_payload, last_names, base_subject, attachments)\n",
+    "    send_emails_with_backoff(service, test_emails_payload, last_names, base_subject, attachments, save_as_draft=save_as_draft)\n",
     "else:\n",
     "    print(\"No test email was set (target email was not found in the list or the list was empty). Skipping test email send.\")"
    ]
@@ -985,7 +996,7 @@
     "\n",
     "# caffeinate -t 1800 &\n",
     "\n",
-    "# which will will launch macOS’s caffeinate utility in the\n",
+    "# which will will launch macOS\u2019s caffeinate utility in the\n",
     "# background (&) and tell it to hold off idle sleep for\n",
     "# 1,800 seconds (30 minutes). In other words, it prevents\n",
     "# your Mac from going to sleep (or dimming the display due\n",
@@ -1006,7 +1017,7 @@
     "\n",
     "# Send personalized HTML emails\n",
     "\n",
-    "send_emails_with_backoff(service, personalized_emails, last_names, base_subject, attachments)\n"
+    "send_emails_with_backoff(service, personalized_emails, last_names, base_subject, attachments, save_as_draft=save_as_draft)\n"
    ]
   },
   {


### PR DESCRIPTION
- Added a `save_as_draft = True` option in the Jupyter Notebook's user configuration cell.
- Updated `SCOPES` to include `'https://www.googleapis.com/auth/gmail.compose'` to allow creating drafts.
- Modified the `send_email` function to conditionally call `service.users().drafts().create` with a slightly modified payload instead of `service.users().messages().send`.
- Updated print statements in `send_emails_with_backoff` to accurately reflect whether an email is being drafted or sent.

---
*PR created automatically by Jules for task [8745513294932457295](https://jules.google.com/task/8745513294932457295) started by @jmswenson*